### PR TITLE
Add install_requires to setup command.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,7 @@ setuptools.setup(
 
     'Operating System :: OS Independent',
     ],
+    install_requires=[
+          'matplotlib>=2.2.0',
+      ]
 )


### PR DESCRIPTION
For proper x-axis sorting version of matplotlib required to be >= 2.2.0
See issue https://github.com/waleedka/hiddenlayer/issues/12
And the corresponding matplotlib issue: https://github.com/matplotlib/matplotlib/issues/9312