### PR TITLE
Fix deprecated torch method call to uniqueName

### DIFF
--- a/hiddenlayer/pytorch_builder.py
+++ b/hiddenlayer/pytorch_builder.py
@@ -42,7 +42,7 @@ def pytorch_id(node):
     """Returns a unique ID for a node."""
     # After ONNX simplification, the scopeName is not unique anymore
     # so append node outputs to guarantee uniqueness
-    return node.scopeName() + "/outputs/" + "/".join([o.debugName() for o in node.outputs()])
+    return node.scopeName() + "/outputs/" + "/".join(["{}".format(o.unique()) for o in node.outputs()])
 
 
 def get_shape(torch_node):

--- a/hiddenlayer/pytorch_builder.py
+++ b/hiddenlayer/pytorch_builder.py
@@ -42,7 +42,7 @@ def pytorch_id(node):
     """Returns a unique ID for a node."""
     # After ONNX simplification, the scopeName is not unique anymore
     # so append node outputs to guarantee uniqueness
-    return node.scopeName() + "/outputs/" + "/".join([o.uniqueName() for o in node.outputs()])
+    return node.scopeName() + "/outputs/" + "/".join([o.debugName() for o in node.outputs()])
 
 
 def get_shape(torch_node):


### PR DESCRIPTION
Fixes #51

`hiddenlayer==0.2.0` is not compatible with `torch==1.2.0` (which is currently the latest installed with `pip3 install torchvision` and overrides an existing/lower `torch` version.) This PR is a simple patch which uses the `unique()` method of a `torch._C.Value` instead of the `uniqueName` method which is missing in `torch==1.2.0`.