### PR TITLE
change occurrence of uniqueName to debugName

### DIFF
--- a/hiddenlayer/pytorch_builder.py
+++ b/hiddenlayer/pytorch_builder.py
@@ -18,7 +18,7 @@ FRAMEWORK_TRANSFORMS = [
     # Hide onnx: prefix
     ht.Rename(op=r"onnx::(.*)", to=r"\1"),
     # ONNX uses Gemm for linear layers (stands for General Matrix Multiplication).
-    # It's an odd name that noone recognizes. Rename it. 
+    # It's an odd name that noone recognizes. Rename it.
     ht.Rename(op=r"Gemm", to=r"Linear"),
     # PyTorch layers that don't have an ONNX counterpart
     ht.Rename(op=r"aten::max\_pool2d\_with\_indices", to="MaxPool"),
@@ -32,17 +32,25 @@ def dump_pytorch_graph(graph):
     f = "{:25} {:40}   {} -> {}"
     print(f.format("kind", "scopeName", "inputs", "outputs"))
     for node in graph.nodes():
-        print(f.format(node.kind(), node.scopeName(),
-                       [i.unique() for i in node.inputs()],
-                       [i.unique() for i in node.outputs()]
-                       ))
+        print(
+            f.format(
+                node.kind(),
+                node.scopeName(),
+                [i.unique() for i in node.inputs()],
+                [i.unique() for i in node.outputs()],
+            )
+        )
 
 
 def pytorch_id(node):
     """Returns a unique ID for a node."""
     # After ONNX simplification, the scopeName is not unique anymore
     # so append node outputs to guarantee uniqueness
-    return node.scopeName() + "/outputs/" + "/".join([o.uniqueName() for o in node.outputs()])
+    return (
+        node.scopeName()
+        + "/outputs/"
+        + "/".join([o.debugName() for o in node.outputs()])
+    )
 
 
 def get_shape(torch_node):
@@ -80,19 +88,26 @@ def import_graph(hl_graph, model, args, input_names=None, verbose=False):
         # Op
         op = torch_node.kind()
         # Parameters
-        params = {k: torch_node[k] for k in torch_node.attributeNames()} 
+        params = {k: torch_node[k] for k in torch_node.attributeNames()}
         # Inputs/outputs
         # TODO: inputs = [i.unique() for i in node.inputs()]
         outputs = [o.unique() for o in torch_node.outputs()]
         # Get output shape
         shape = get_shape(torch_node)
         # Add HL node
-        hl_node = Node(uid=pytorch_id(torch_node), name=None, op=op, 
-                       output_shape=shape, params=params)
+        hl_node = Node(
+            uid=pytorch_id(torch_node),
+            name=None,
+            op=op,
+            output_shape=shape,
+            params=params,
+        )
         hl_graph.add_node(hl_node)
         # Add edges
         for target_torch_node in torch_graph.nodes():
             target_inputs = [i.unique() for i in target_torch_node.inputs()]
             if set(outputs) & set(target_inputs):
-                hl_graph.add_edge_by_id(pytorch_id(torch_node), pytorch_id(target_torch_node), shape)
+                hl_graph.add_edge_by_id(
+                    pytorch_id(torch_node), pytorch_id(target_torch_node), shape
+                )
     return hl_graph


### PR DESCRIPTION
`uniqueName` has been re-named to `debugName` in [`torch.utils.tensorboard._pytorch_graph`](https://github.com/pytorch/pytorch/blob/master/torch/utils/tensorboard/_pytorch_graph.py#L19) for torch version ≥ 1.2.0.